### PR TITLE
fix regresion included in 0c31aec7726b98c8158c0334b62ad2d76e292f67

### DIFF
--- a/sys/FireShock/Power.c
+++ b/sys/FireShock/Power.c
@@ -119,7 +119,8 @@ FireShockEvtDevicePrepareHardware(
         status = WdfObjectAllocateContext(Device, &attributes, (PVOID)&pDs4Context);
         if (!NT_SUCCESS(status))
         {
-            KdPrint((DRIVERNAME "WdfObjectAllocateContext failed status 0x%x\n", status));
+            TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_POWER,
+                "WdfObjectAllocateContext failed status %!STATUS!", status);
             return status;
         }
 


### PR DESCRIPTION
Used old `KdPrint` methord instead of the `TraceEvents` methord, failed to compile as `DRIVERNAME` was undefined.